### PR TITLE
Use prototype-less object for `parentInjections`

### DIFF
--- a/src/getPatchFunc.ts
+++ b/src/getPatchFunc.ts
@@ -19,7 +19,7 @@ export default <CallbackType extends Function>(patchType: PatchType) =>
         `${funcName} is not a function in ${funcParent.constructor.name}`
       );
 
-    if (!patchedObjects.has(funcParent)) patchedObjects.set(funcParent, {});
+    if (!patchedObjects.has(funcParent)) patchedObjects.set(funcParent, Object.create(null));
 
     const parentInjections = patchedObjects.get(funcParent);
 


### PR DESCRIPTION
When targeting a function which name is one if the `Object.prototype` properties (like `toString`), it will fail due to the `if (!parentInjections[funcName]) {` check getting skipped