### PR TITLE
fix: uncomplicate type definitions

### DIFF
--- a/src/getPatchFunc.ts
+++ b/src/getPatchFunc.ts
@@ -4,27 +4,30 @@
 
 import hook from "./hook";
 import {
-  AnyObject,
-  KeysWithFunctionValues,
   PatchType,
-  PatchTypeToCallbackMap,
   patchedFunctions,
 } from "./shared";
 import { unpatch } from "./unpatch";
 
+interface CallbackTypes<F extends (...args: any[]) => any> {
+  b: (args: Parameters<F>) => Parameters<F> | void | undefined;
+  i: (args: Parameters<F>, origFunc: NonNullable<F>) => ReturnType<F>;
+  a: (args: Parameters<F>, ret: ReturnType<F>) => ReturnType<F> | void | undefined;
+}
+
 // creates a hook if needed, else just adds one to the patches array
 export default <T extends PatchType>(patchType: T) =>
-  <Name extends KeysWithFunctionValues<Parent>, Parent extends AnyObject>(
-    funcName: Name,
-    funcParent: Parent,
-    callback: PatchTypeToCallbackMap<Parent[Name]>[T],
+  <N extends keyof P, P extends Record<PropertyKey, any>>(
+    funcName: N,
+    funcParent: P,
+    callback: CallbackTypes<P[N]>[T],
     oneTime = false
   ) => {
     let origFunc = funcParent[funcName];
 
     if (typeof origFunc !== "function")
       throw new Error(
-        `${funcName} is not a function in ${funcParent.constructor.name}`
+        `${String(funcName)} is not a function in ${funcParent.constructor.name}`
       );
 
     let funcPatch = patchedFunctions.get(origFunc);

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,9 +1,9 @@
 // calls relevant patches and returns the final result
-import { AnyFunction, patchedFunctions } from "./shared";
+import { patchedFunctions } from "./shared";
 
 export default function (
-  patchedFunc: AnyFunction,
-  origFunc: AnyFunction,
+  patchedFunc: Function,
+  origFunc: Function,
   funcArgs: unknown[],
   // the value of `this` to apply
   ctxt: any

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,42 +1,28 @@
 export type PatchType = "a" | "b" | "i";
 
-export type PatchTypeToCallbackMap<F extends AnyFunction> = {
-  a: (args: Parameters<F>, ret: ReturnType<F>) => ReturnType<F>;
-  b: (args: Parameters<F>) => Parameters<F> | void | undefined;
-  i: (args: Parameters<F>, origFunc: F) => ReturnType<F>;
-}
-
 // we use this array multiple times
 export const patchTypes: PatchType[] = ["a", "b", "i"];
 
 export type Patch = {
   // function name
-  n: string;
+  n: PropertyKey;
   // original function
-  o: AnyFunction;
+  o: Function;
   // WeakRef to parent object
   p: WeakRef<any>;
   // cleanups
   c: Function[];
   // after hooks
-  a: Map<symbol, AnyFunction>;
+  a: Map<symbol, Function>;
   // before hooks
-  b: Map<symbol, AnyFunction>;
+  b: Map<symbol, Function>;
   // instead hooks
-  i: Map<symbol, AnyFunction>;
+  i: Map<symbol, Function>;
 };
 
-export type AnyFunction = (...args: any[]) => any;
-
-export type KeysWithFunctionValues<T extends AnyObject> = {
-  [K in Extract<keyof T, string>]: T[K] extends AnyFunction ? K : never
-}[Extract<keyof T, string>];
-
-export type AnyObject = Record<any, any>;
-
-export let patchedFunctions: WeakMap<AnyFunction, Patch>;
+export let patchedFunctions: WeakMap<Function, Patch>;
 export let resetPatches = () =>
-  (patchedFunctions = new WeakMap<AnyFunction, Patch>());
+  (patchedFunctions = new WeakMap<Function, Patch>());
 
 // Manual minification is funny
 resetPatches();


### PR DESCRIPTION
the type definitions used in spitroast have been a touchy subject for a long time. the adjustments made by this pull request should hopefully end that. they are considerably less complex, but still robust and well-tested - i've been using them in my fork, strawberry, for a while now.

this DOES induce a file size regression, but fixes an actual runtime regression:

> ``${String(funcName)} is not a function in ${funcParent.constructor.name}``

i am now explicitly casting `funcName` to `String`, which is needed as it can be `symbol` which errors if implicitly cast at runtime.